### PR TITLE
[vultr] reduce CPU usage + README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ docker run -ti --rm abagayev/stop-russia
   - DigitalOcean | [README](automation/digitaocean#-digitalocean-droplet-автоматизація)
   - Google Cloud Platform | [README](automation/gcp-gcloud#-google-cloud-platform-gcp-vm-автоматизація)
   - Linode | [README](automation/linode#-linode-автоматизація)
+  - Vultr | [README](automation/vultr#-vultr-автоматизація)
 
 ### Запуск зі своєї машини
 
@@ -85,6 +86,7 @@ To automate cloud deployment, look in the `automation` folder, there are now the
   - DigitalOcean | [README](automation/digitaocean#-digitalocean-droplet-automation)
   - Google Cloud Platform | [README](automation/gcp-gcloud#-google-cloud-platform-gcp-vm-automation)
   - Linode | [README](automation/linode#-linode-automation)
+  - Vultr | [README](automation/vultr#-vultr-automation)
 
 ### Restrictions
 

--- a/automation/digitaocean/userdata.sh
+++ b/automation/digitaocean/userdata.sh
@@ -3,7 +3,7 @@
 apt -y update
 apt -y install docker.io
 
-fallocate -l 1G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile 
+fallocate -l 1G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /swapfile
 
 NUMPROC=5
 

--- a/automation/vultr/init.sh
+++ b/automation/vultr/init.sh
@@ -7,10 +7,18 @@ PLAN=vc2-1c-1gb
 # Ubuntu 20.04 x64
 OS=387
 
+# Full CPU script below, note that Vultr can slow down or terminate your instance, or ban your account. Uncomment on your own accord.
+# SCRIPT_RESPONSE=$(vultr-cli script create \
+#   --type boot \
+#   --name stop-russia-100-cpu \
+#   --script IyEvYmluL2Jhc2gNCg0KYXB0IC15IHVwZGF0ZQ0KYXB0IC15IGluc3RhbGwgZG9ja2VyLmlvDQoNCmZhbGxvY2F0ZSAtbCAxRyAvc3dhcGZpbGUgJiYgY2htb2QgNjAwIC9zd2FwZmlsZSAmJiBta3N3YXAgL3N3YXBmaWxlICYmIHN3YXBvbiAvc3dhcGZpbGUNCg0KTlVNUFJPQz01DQoNCmZvciBwcm9jIGluICQoc2VxIDEgJE5VTVBST0MpOyBkbw0KICBzY3JlZW4gLWQgLW0gZG9ja2VyIHJ1biAtdGkgLS1ybSBhYmFnYXlldi9zdG9wLXJ1c3NpYQ0KZG9uZQ0K | head -n1)
+
+# 0.8 CPU script below. Recommended.
 SCRIPT_RESPONSE=$(vultr-cli script create \
   --type boot \
-  --name stop-russia \
-  --script IyEvYmluL2Jhc2gNCg0KYXB0IC15IHVwZGF0ZQ0KYXB0IC15IGluc3RhbGwgZG9ja2VyLmlvDQoNCmZhbGxvY2F0ZSAtbCAxRyAvc3dhcGZpbGUgJiYgY2htb2QgNjAwIC9zd2FwZmlsZSAmJiBta3N3YXAgL3N3YXBmaWxlICYmIHN3YXBvbiAvc3dhcGZpbGUNCg0KTlVNUFJPQz01DQoNCmZvciBwcm9jIGluICQoc2VxIDEgJE5VTVBST0MpOyBkbw0KICBzY3JlZW4gLWQgLW0gZG9ja2VyIHJ1biAtdGkgLS1ybSBhYmFnYXlldi9zdG9wLXJ1c3NpYQ0KZG9uZQ0K | head -n1)
+  --name stop-russia-80-cpu \
+  --script IyEvYmluL2Jhc2gNCg0KYXB0IC15IHVwZGF0ZQ0KYXB0IC15IGluc3RhbGwgZG9ja2VyLmlvDQoNCmZhbGxvY2F0ZSAtbCAxRyAvc3dhcGZpbGUgJiYgY2htb2QgNjAwIC9zd2FwZmlsZSAmJiBta3N3YXAgL3N3YXBmaWxlICYmIHN3YXBvbiAvc3dhcGZpbGUgDQoNCk5VTVBST0M9NQ0KDQpmb3IgcHJvYyBpbiAkKHNlcSAxICROVU1QUk9DKTsgZG8NCiAgc2NyZWVuIC1kIC1tIGRvY2tlciBydW4gLXRpIC0tY3B1cz0iLjgiIC0tcm0gYWJhZ2F5ZXYvc3RvcC1ydXNzaWENCmRvbmUNCg== | head -n1)
+
 SCRIPT_RESPONSE_ARRAY=(${SCRIPT_RESPONSE// / })
 SCRIPT_ID=${SCRIPT_RESPONSE_ARRAY[1]}
 


### PR DESCRIPTION
- понизив CPU до 0.8
- додав лінки на Vultr в README

Оригінальний лист:

```
from:  abusenotification@vultr.com <abusenotification@vultr.com>

---

Dear Customer,

A support ticket has been created in our system on your behalf. Here is the ticket summary:

Based on monitoring results and subsequent analysis, we have determined your CPU resource utilization profile is excessive and causing performance issues which may unfairly affect the population of Vultr subscribers as a whole. Accordingly, we have limited the maximum CPU resources your instances can consume (an account-wide setting). If you are able to reduce the performance impact we have observed, we may be able to adjust the limit or remove it altogether.

Thank you for your cooperation!

To manage or update your ticket, please visit:
https://my.vultr.com/support/view_ticket/?TICKETID=

Did you know? Vultr has a wealth of knowledge located at https://www.vultr.com/docs/

Thank you for choosing Vultr.com!
```

Скріни:

<img width="1263" alt="Screenshot 2022-03-07 at 22 25 42" src="https://user-images.githubusercontent.com/25356465/157115479-4b4b1d3a-343c-4b4b-ad34-28f129e22228.png">

<img width="1287" alt="Screenshot 2022-03-07 at 22 25 53" src="https://user-images.githubusercontent.com/25356465/157115482-270d7159-1fae-4c82-8d92-1bf753fb0323.png">

