### PR TITLE
[linode] reduce CPU to prevent ban

### DIFF
--- a/automation/linode/stackscript.sh
+++ b/automation/linode/stackscript.sh
@@ -8,5 +8,5 @@ fallocate -l 1G /swapfile && chmod 600 /swapfile && mkswap /swapfile && swapon /
 NUMPROC=5
 
 for proc in $(seq 1 $NUMPROC); do
-  screen -d -m docker run -ti --rm abagayev/stop-russia
+  screen -d -m docker run -ti --cpus=".8" --rm abagayev/stop-russia
 done


### PR DESCRIPTION
# Історія.

#### Спочатку приходили алерти про трафік та CPU:

<img width="1086" alt="Screenshot 2022-03-12 at 00 21 20" src="https://user-images.githubusercontent.com/25356465/157980528-d1bae352-b30d-4343-8a9d-5ad4446edc9a.png">

#### Проте, в самих алертах було написано наступне:

```
This is not meant as a warning or a representation that you are misusing your resources.  We encourage you to modify the thresholds based on your own individual needs.
```

#### Тому я ігнорував ці алерти весь тиждень, але сьогодні без пояснень аккаунт деактивували, при спробі створити аккаунт ще раз прийшов наступний лист:

<img width="671" alt="Screenshot 2022-03-12 at 00 25 15" src="https://user-images.githubusercontent.com/25356465/157981213-98734a01-6f56-4724-9e59-2e79b1860d07.png">

#### Я не впевнений чи мій аккаунт попав під роздачу через велику кількість алертів, чи просто вони просканували інстанси, проте якщо зниження CPU допоможе не попадати під радар деякий час, то хай буде .8. Що думаєте?

